### PR TITLE
Add countProps helper using Object.keys

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -16,6 +16,8 @@ export function addSpaces(text: string): string {
         .join('');
 }
 
+export const countProps = (object: Record<string, unknown>): number => Object.keys(object).length;
+
 ///////////////////////////////////////////////////////
 //For Time and Date Pickers
 


### PR DESCRIPTION
### Motivation
- Provide a small utility to return the number of own properties of an object using `Object.keys`, replacing manual `for…in` iterations.

### Description
- Add `export const countProps = (object: Record<string, unknown>): number => Object.keys(object).length;` to `utils/helpers.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698795136b40833299de8b29e715462c)